### PR TITLE
Fix absolute path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 # Перейти в директорию проекта
-cd /Users/aleksandrbobrov/Developer/personal/nullianism/nullianism.github.io
+cd path/to/nullianism.github.io
 
 # Установить зависимости (если еще не установлены)
 npm install


### PR DESCRIPTION
## Summary
- use a placeholder path for the project directory

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb9b536a4832787b3426f27b291dd